### PR TITLE
データをセットするときのロックする位置を修正する

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -43,7 +43,7 @@ func (c *LocalCache) Get(key string) []byte {
 // Set is ...
 func (c *LocalCache) Set(key string, src []byte) error {
 	if c.Data == nil {
-		return fmt.Errorf("error: nil map")
+		return fmt.Errorf("error: nil map access")
 	}
 
 	if len(src) == 0 {

--- a/cache.go
+++ b/cache.go
@@ -42,9 +42,6 @@ func (c *LocalCache) Get(key string) []byte {
 
 // Set is ...
 func (c *LocalCache) Set(key string, src []byte) error {
-	c.m.Lock()
-	defer c.m.Unlock()
-
 	if c.Data == nil {
 		return fmt.Errorf("error: nil map")
 	}
@@ -52,6 +49,9 @@ func (c *LocalCache) Set(key string, src []byte) error {
 	if len(src) == 0 {
 		return fmt.Errorf("error: set no data")
 	}
+
+	c.m.Lock()
+	defer c.m.Unlock()
 
 	c.Data[key] = src
 	return nil


### PR DESCRIPTION
## これは何か？

掲題の通り。
map に key と バリューをセットするときにロックをするが、map の検査後、実際にデータをセットする直前でロックを取るように修正する。