### PR TITLE
LocalCache -> MemoryCache に変更する。

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -7,12 +7,12 @@ import (
 )
 
 var (
-	// DefaultLocalCacheExpires is 60 seconds
-	DefaultLocalCacheExpires int64 = 60
+	// DefaultMemoryCacheExpires is 60 seconds
+	DefaultMemoryCacheExpires int64 = 60
 )
 
-// LocalCache is cache data in local which has expiration date.
-type LocalCache struct {
+// MemoryCache is cache data in local which has expiration date.
+type MemoryCache struct {
 	Data    map[string][]byte
 	Expires int64
 	m       sync.RWMutex
@@ -20,7 +20,7 @@ type LocalCache struct {
 
 // Get returns a item or nil.
 // If cache in local is nil or expiration date of the cache you want to retrive is earlier, you can't retrive cache.
-func (c *LocalCache) Get(key string) []byte {
+func (c *MemoryCache) Get(key string) []byte {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
@@ -36,7 +36,7 @@ func (c *LocalCache) Get(key string) []byte {
 }
 
 // Set add a new data for cache with a new key or replace an exist key.
-func (c *LocalCache) Set(key string, src []byte) error {
+func (c *MemoryCache) Set(key string, src []byte) error {
 	if c.Data == nil {
 		return fmt.Errorf("error: nil map access")
 	}
@@ -52,12 +52,12 @@ func (c *LocalCache) Set(key string, src []byte) error {
 	return nil
 }
 
-// NewLocalCache creates a new LocalCache for given a its expires.
+// NewMemoryCache creates a new MemoryCache for given a its expires.
 // If exp is 0, you will use the default cache expiration.
 // The default cache expiration is 60 seconds.
-func NewLocalCache(exp int64) *LocalCache {
+func NewMemoryCache(exp int64) *MemoryCache {
 	if exp == 0 {
-		exp = DefaultLocalCacheExpires
+		exp = DefaultMemoryCacheExpires
 	}
-	return &LocalCache{Data: map[string][]byte{}, Expires: exp}
+	return &MemoryCache{Data: map[string][]byte{}, Expires: exp}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -7,26 +7,26 @@ import (
 
 var testKey = "testKey"
 
-func TestLocalCache_Get(t *testing.T) {
+func TestMemoryCache_Get(t *testing.T) {
 	now := time.Now()
 	tests := []struct {
 		name string
-		fake *LocalCache
+		fake *MemoryCache
 		want bool
 	}{
 		{
 			name: "exist cache",
-			fake: &LocalCache{Data: map[string][]byte{testKey: []byte("hoge")}, Expires: now.Add(60 * time.Second).Unix()},
+			fake: &MemoryCache{Data: map[string][]byte{testKey: []byte("hoge")}, Expires: now.Add(60 * time.Second).Unix()},
 			want: true,
 		},
 		{
 			name: "cache expired",
-			fake: &LocalCache{Data: map[string][]byte{testKey: []byte("hoge")}, Expires: now.Add(-60 * time.Second).Unix()},
+			fake: &MemoryCache{Data: map[string][]byte{testKey: []byte("hoge")}, Expires: now.Add(-60 * time.Second).Unix()},
 			want: false,
 		},
 		{
 			name: "cache not exist",
-			fake: &LocalCache{Data: nil, Expires: now.Add(-60 * time.Second).Unix()},
+			fake: &MemoryCache{Data: nil, Expires: now.Add(-60 * time.Second).Unix()},
 			want: false,
 		},
 	}
@@ -42,7 +42,7 @@ func TestLocalCache_Get(t *testing.T) {
 	}
 }
 
-func TestLocalCache_Set(t *testing.T) {
+func TestMemoryCache_Set(t *testing.T) {
 	tests := []struct {
 		name string
 		arg  []byte
@@ -55,7 +55,7 @@ func TestLocalCache_Set(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewLocalCache(time.Now().Add(60 * time.Second).Unix())
+			c := NewMemoryCache(time.Now().Add(60 * time.Second).Unix())
 			err := c.Set(testKey, tt.arg)
 			if (err != nil) != tt.want {
 				t.Fatalf("failed to set cache. err is %v but wantErr is %v", err, tt.want)


### PR DESCRIPTION
## これは何か？

掲題の通りです。
LocalCache と銘打った場合、その指し示す先として、インメモリキャッシュやファイルキャッシュが想起されますが、初期の実装ではインメモリキャッシュを LocalCache としていて名前に違和感がありました。

そのため用途をさらに限定するために LocalCache struct を MemoryCache struct に変更します。

ref: https://github.com/emahiro/glc/issues/8