### PR TITLE
MemoryCacheをインスタンス化するときの有効期限の型を変更する

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -7,7 +7,7 @@ import (
 )
 
 // DefaultMemoryCacheExpires is 60 seconds
-const DefaultMemoryCacheExpires int64 = 60
+const DefaultMemoryCacheExpires = 60 * time.Second
 
 // MemoryCache is cache data in memory which has expiration date.
 type MemoryCache struct {
@@ -53,9 +53,9 @@ func (c *MemoryCache) Set(key string, src []byte) error {
 // NewMemoryCache creates a new MemoryCache for given a its expires.
 // If exp is 0, you will use the default cache expiration.
 // The default cache expiration is 60 seconds.
-func NewMemoryCache(exp int64) *MemoryCache {
+func NewMemoryCache(exp time.Duration) *MemoryCache {
 	if exp == 0 {
 		exp = DefaultMemoryCacheExpires
 	}
-	return &MemoryCache{data: map[string][]byte{}, expires: exp}
+	return &MemoryCache{data: map[string][]byte{}, expires: time.Now().Add(exp).Unix()}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -55,7 +55,7 @@ func TestMemoryCache_Set(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewMemoryCache(time.Now().Add(60 * time.Second).Unix())
+			c := NewMemoryCache(10 * time.Second)
 			err := c.Set(testKey, tt.arg)
 			if (err != nil) != tt.want {
 				t.Fatalf("failed to set cache. err is %v but wantErr is %v", err, tt.want)


### PR DESCRIPTION
## これは何か?

掲題の通りです。

MemoryCache をインスタンス化するとき有効期限を外部から差し込むシグネチャにしていますが、この有効期限が指定されていない = 0 のときに0がそのまま exp に指定され、期待する 60 sec のキャッシュの挙動になっておりませんでした。

そこでシグネチャを再度検討し、 `time.Duration` 型として指定することにします。