### PR TITLE
fix golint

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -5,7 +5,7 @@ Example:
 	mc := NewMemoryCache(cache.DefaultMemoryCacheExpires)
 
 	// Set
-	if err := mc.Set("cacheKey", []byte('hoge')); err != nil{
+	if err := mc.Set("cacheKey", []byte('hoge')); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cache.go
+++ b/cache.go
@@ -1,16 +1,16 @@
 /*
-	Package cache is provides the local cache which is stored in memoroy or file.
+Package cache is provides the local cache which is stored in memoroy or file.
 
-	Example:
-		mc := NewMemoryCache(cache.DefaultMemoryCacheExpires)
+Example:
+	mc := NewMemoryCache(cache.DefaultMemoryCacheExpires)
 
-		// Set
-		if err := mc.Set("cacheKey", []byte('hoge')); err != nil{
-			log.Fatal(err)
-		}
+	// Set
+	if err := mc.Set("cacheKey", []byte('hoge')); err != nil{
+		log.Fatal(err)
+	}
 
-		// Get
-		data := mc.Get("cacheKey")
+	// Get
+	data := mc.Get("cacheKey")
 */
 package cache
 


### PR DESCRIPTION
## これ何か？

`golint` かけたときの `cache.go:1:1: package comment should not have leading space` の警告があったのでこちらを修正します。