### PR TITLE
有効期限指定を time.Duration -> time.Time に変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ go get github.com/emahiro/glc
 ## Usage
 
 ```go
-mc := NewMemoryCache(cache.DefaultMemoryCacheExpires)
+mc := NewMemoryCache(cache.DefaultMemoryCacheExpires*time.Second)
 
 // Set
 if err := mc.Set("cacheKey", []byte('hoge')); err != nil {

--- a/cache.go
+++ b/cache.go
@@ -2,7 +2,7 @@
 Package cache is provides the local cache which is stored in memoroy or file.
 
 Example:
-	mc := NewMemoryCache(cache.DefaultMemoryCacheExpires)
+	mc := NewMemoryCache(time.Now().Add(cache.DefaultMemoryCacheExpires*time.Second))
 
 	// Set
 	if err := mc.Set("cacheKey", []byte('hoge')); err != nil {
@@ -64,7 +64,7 @@ func (c *MemoryCache) Set(key string, src []byte) error {
 	return nil
 }
 
-// NewMemoryCache creates a new MemoryCache for given a its expires.
+// NewMemoryCache creates a new MemoryCache for given a its expires as time.Time.
 // If exp is 0, you will use the default cache expiration.
 // The default cache expiration is 60 seconds.
 func NewMemoryCache(exp time.Time) *MemoryCache {

--- a/cache.go
+++ b/cache.go
@@ -21,7 +21,7 @@ import (
 )
 
 // DefaultMemoryCacheExpires is 60 seconds
-const DefaultMemoryCacheExpires = 60 * time.Second
+const DefaultMemoryCacheExpires = 60
 
 // MemoryCache is cache data in memory which has expiration date.
 type MemoryCache struct {
@@ -67,9 +67,9 @@ func (c *MemoryCache) Set(key string, src []byte) error {
 // NewMemoryCache creates a new MemoryCache for given a its expires.
 // If exp is 0, you will use the default cache expiration.
 // The default cache expiration is 60 seconds.
-func NewMemoryCache(exp time.Duration) *MemoryCache {
-	if exp == 0 {
-		exp = DefaultMemoryCacheExpires
+func NewMemoryCache(exp time.Time) *MemoryCache {
+	if exp.IsZero() {
+		exp = time.Now().Add(DefaultMemoryCacheExpires * time.Second)
 	}
-	return &MemoryCache{data: map[string][]byte{}, expires: time.Now().Add(exp).Unix()}
+	return &MemoryCache{data: map[string][]byte{}, expires: exp.Unix()}
 }

--- a/cache_test.go
+++ b/cache_test.go
@@ -55,7 +55,7 @@ func TestMemoryCache_Set(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewMemoryCache(10 * time.Second)
+			c := NewMemoryCache(time.Now().Add(60 * time.Second))
 			err := c.Set(testKey, tt.arg)
 			if (err != nil) != tt.want {
 				t.Fatalf("failed to set cache. err is %v but wantErr is %v", err, tt.want)

--- a/cache_test.go
+++ b/cache_test.go
@@ -55,7 +55,7 @@ func TestMemoryCache_Set(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewMemoryCache(time.Now().Add(60 * time.Second))
+			c := NewMemoryCache(time.Now().Add(DefaultMemoryCacheExpires * time.Second))
 			err := c.Set(testKey, tt.arg)
 			if (err != nil) != tt.want {
 				t.Fatalf("failed to set cache. err is %v but wantErr is %v", err, tt.want)


### PR DESCRIPTION
## これは何か？

インメモリキャッシュの有効期限を指定する際に `time.Duration` を引数として提供していましたが、これを `time.Time` に変更します。

変更の意図としては

- expires は「有効期限」で概念としては何分後か？(duration) ではなく、時刻そのものを指す。
- このライブラリのユースケースとしては、APIで取得したアクセストークンや公開鍵の有効期限をセットすることを目的に作っているので、APIから返されるレスポンスはdurationよりどちらかというと時刻そのものを返すケースの方が多いので、時刻そのものをダイレクトに指定できるようにする。