### PR TITLE
MemoryCache の Item filed を追加する。

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go get github.com/emahiro/glc
 ### in memory cache
 
 ```go
-mc := NewMemoryCache(time.Now().Add(cache.DefaultMemoryCacheExpires*time.Second)
+mc := NewMemoryCache(DefaultMemoryCacheExpires)
 
 // Set
 if err := mc.Set("cacheKey", []byte('hoge')); err != nil {

--- a/cache.go
+++ b/cache.go
@@ -3,7 +3,7 @@ Package cache is provides the local cache which is stored in memoroy or file.
 This package creates `tmp` directory for file cache, when you provide UseFileCache true.
 
 Example:
-	mc := NewMemoryCache(time.Now().Add(cache.DefaultMemoryCacheExpires*time.Second))
+	mc := NewMemoryCache(cache.DefaultMemoryCacheExpires)
 
 	// Set
 	if err := mc.Set("cacheKey", []byte('hoge')); err != nil {
@@ -42,7 +42,7 @@ type MemoryCache struct {
 	m    sync.RWMutex
 }
 
-// Item has cache item and expiration.
+// Item has cache item and expiration field.
 type Item struct {
 	data []byte
 	exp  int64
@@ -97,9 +97,7 @@ func (c *MemoryCache) Set(key string, src []byte) error {
 	return nil
 }
 
-// NewMemoryCache creates a new MemoryCache for given a its expires as time.Time.
-// If exp is 0, you will use the default cache expiration.
-// The default cache expiration is 60 seconds.
+// NewMemoryCache creates a new MemoryCache for given a its expires as time.Duration.
 func NewMemoryCache(d time.Duration) *MemoryCache {
 	return &MemoryCache{item: make(map[string]*Item), d: d}
 }

--- a/cache.go
+++ b/cache.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// DefaultMemoryCacheExpires is 60 seconds
-	DefaultMemoryCacheExpires = 60
+	DefaultMemoryCacheExpires = 60 * time.Second
 	fileCacheDir              = "tmp"
 )
 
@@ -35,11 +35,17 @@ var (
 	UseFileCache = false
 )
 
-// MemoryCache is cache data in memory which has expiration date.
+// MemoryCache is cache data in memory which has duration.
 type MemoryCache struct {
-	data    map[string][]byte
-	expires int64
-	m       sync.RWMutex
+	item map[string]*Item
+	d    time.Duration
+	m    sync.RWMutex
+}
+
+// Item has cache item and expiration.
+type Item struct {
+	data []byte
+	exp  int64
 }
 
 func init() {
@@ -60,20 +66,20 @@ func (c *MemoryCache) Get(key string) []byte {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	now := time.Now().Unix()
-	if c == nil || c.expires < now {
+	item, ok := c.item[key]
+	if !ok || item == nil {
+		return nil
+	}
+	if len(item.data) == 0 || item.exp < time.Now().UnixNano() {
 		return nil
 	}
 
-	if data, ok := c.data[key]; ok && len(data) != 0 {
-		return data
-	}
-	return nil
+	return item.data
 }
 
 // Set add a new data for cache with a new key or replace an exist key.
 func (c *MemoryCache) Set(key string, src []byte) error {
-	if c.data == nil {
+	if c.item == nil {
 		return fmt.Errorf("error: nil map access")
 	}
 
@@ -84,18 +90,18 @@ func (c *MemoryCache) Set(key string, src []byte) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	c.data[key] = src
+	c.item[key] = &Item{
+		data: src,
+		exp:  time.Now().Add(c.d).UnixNano(),
+	}
 	return nil
 }
 
 // NewMemoryCache creates a new MemoryCache for given a its expires as time.Time.
 // If exp is 0, you will use the default cache expiration.
 // The default cache expiration is 60 seconds.
-func NewMemoryCache(exp time.Time) *MemoryCache {
-	if exp.IsZero() {
-		exp = time.Now().Add(DefaultMemoryCacheExpires * time.Second)
-	}
-	return &MemoryCache{data: map[string][]byte{}, expires: exp.Unix()}
+func NewMemoryCache(d time.Duration) *MemoryCache {
+	return &MemoryCache{item: make(map[string]*Item), d: d}
 }
 
 // FileCache is cache data in local file.

--- a/cache_test.go
+++ b/cache_test.go
@@ -33,17 +33,38 @@ func TestMemoryCache_Get(t *testing.T) {
 	}{
 		{
 			name: "exist cache",
-			fake: &MemoryCache{data: map[string][]byte{testKey: []byte("hoge")}, expires: now.Add(60 * time.Second).Unix()},
+			fake: &MemoryCache{
+				item: map[string]*Item{
+					testKey: &Item{
+						data: []byte("hoge"),
+						exp:  now.Add(DefaultMemoryCacheExpires).UnixNano(),
+					},
+				},
+			},
 			want: true,
 		},
 		{
 			name: "cache expired",
-			fake: &MemoryCache{data: map[string][]byte{testKey: []byte("hoge")}, expires: now.Add(-60 * time.Second).Unix()},
+			fake: &MemoryCache{
+				item: map[string]*Item{
+					testKey: &Item{
+						data: []byte("hoge"),
+						exp:  now.Add(-1 * time.Nanosecond).UnixNano(),
+					},
+				},
+			},
 			want: false,
 		},
 		{
 			name: "cache not exist",
-			fake: &MemoryCache{data: nil, expires: now.Add(-60 * time.Second).Unix()},
+			fake: &MemoryCache{
+				item: map[string]*Item{
+					testKey: &Item{
+						data: nil,
+						exp:  now.Add(DefaultMemoryCacheExpires).UnixNano(),
+					},
+				},
+			},
 			want: false,
 		},
 	}
@@ -72,7 +93,7 @@ func TestMemoryCache_Set(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			c := NewMemoryCache(time.Now().Add(DefaultMemoryCacheExpires * time.Second))
+			c := NewMemoryCache(DefaultMemoryCacheExpires)
 			err := c.Set(testKey, tt.arg)
 			if (err != nil) != tt.want {
 				t.Fatalf("failed to set cache. err is %v but wantErr is %v", err, tt.want)


### PR DESCRIPTION
## What

`MemoryCache` struct に直にキャッシュするデータを持たせてましたが、このままだと keyごとにデータは指定できるが、全てのキャッシュするデータに対して有効期限が一つしか指定できず、意図した挙動になりません。
そのため、`MemoryCache` の構造体に `map[string]*Item` して `Item` あたりにデータと有効期限を持たせることにします。

これによりメモリキャッシュのもつ Duration をもとに各 `Item` のもつ有効期限を計算することができ、キャッシュごとに有効期限を持つという意図した挙動になります。

変更点

- NewMemoryCache ではキャッシュごとの有効期限を計算するために何分キャッシュするのか？を指定します。このため、引数の型は `time.Duration` です。
- テストを合わせて修正します。
- キャッシュの厳密性を担保するために有効期限は `Unix Nano Second` を指定します。

