### PR TITLE
パッケージ名を glc に変更する

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ go get github.com/emahiro/glc
 ### in memory cache
 
 ```go
-mc := NewMemoryCache(DefaultMemoryCacheExpires)
+mc := glc.NewMemoryCache(glc.DefaultMemoryCacheExpires)
 
 // Set
 if err := mc.Set("cacheKey", []byte('hoge')); err != nil {

--- a/cache.go
+++ b/cache.go
@@ -3,7 +3,7 @@ Package cache is provides the local cache which is stored in memoroy or file.
 This package creates `tmp` directory for file cache, when you provide UseFileCache true.
 
 Example:
-	mc := NewMemoryCache(cache.DefaultMemoryCacheExpires)
+	mc := glc.NewMemoryCache(glc.DefaultMemoryCacheExpires)
 
 	// Set
 	if err := mc.Set("cacheKey", []byte('hoge')); err != nil {
@@ -13,7 +13,7 @@ Example:
 	// Get
 	data := mc.Get("cacheKey")
 */
-package cache
+package glc
 
 import (
 	"fmt"

--- a/cache_test.go
+++ b/cache_test.go
@@ -1,4 +1,4 @@
-package cache
+package glc
 
 import (
 	"os"


### PR DESCRIPTION
## これは何か？
パッケージ名をリポジトリ名に合わせて glc に変更します。

理由は import するときに alias として `cache` がついてしまうためです。
alias がついてもいいんですが、Goらしくないのとalias がつくとネームスペースの衝突が起こりそうなので。