### PR TITLE
Local File Cache の改善

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -97,7 +97,7 @@ func (c *FileCache) Get(key string) []byte {
 	c.m.RLock()
 	defer c.m.RUnlock()
 
-	fp := filepath.Join(".", fileCacheDir, fmt.Sprintf("%s.cache", key))
+	fp := filepath.Join(c.path, key) + ".cache"
 	b, err := ioutil.ReadFile(fp)
 	if err != nil {
 		return nil
@@ -117,13 +117,7 @@ func (c *FileCache) Set(key string, src []byte) error {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	fp := filepath.Join(".", fileCacheDir, fmt.Sprintf("%s.cache", key))
-	if _, err := os.Stat(fp); os.IsNotExist(err) {
-		if _, err := os.Create(fp); err != nil {
-			return fmt.Errorf("set cache error. err:%v", err)
-		}
-	}
-
+	fp := filepath.Join(c.path, key) + ".cache"
 	if err := ioutil.WriteFile(fp, src, os.ModePerm); err != nil {
 		return fmt.Errorf("set cache error. err: %v", err)
 	}

--- a/cache.go
+++ b/cache.go
@@ -30,11 +30,6 @@ const (
 	fileCacheDir              = "tmp"
 )
 
-var (
-	// UseFileCache is flag whitch control file cache usage
-	UseFileCache = false
-)
-
 // MemoryCache is cache data in memory which has duration.
 type MemoryCache struct {
 	item map[string]*Item
@@ -46,18 +41,6 @@ type MemoryCache struct {
 type Item struct {
 	data []byte
 	exp  int64
-}
-
-func init() {
-	if !UseFileCache {
-		return
-	}
-
-	if _, err := os.Stat(fileCacheDir); os.IsNotExist(err) {
-		if err := os.Mkdir(fileCacheDir, os.ModePerm); err != nil {
-			panic(err)
-		}
-	}
 }
 
 // Get returns a item or nil.

--- a/cache.go
+++ b/cache.go
@@ -104,7 +104,8 @@ func NewMemoryCache(d time.Duration) *MemoryCache {
 
 // FileCache is cache data in local file.
 type FileCache struct {
-	m sync.RWMutex
+	path string
+	m    sync.RWMutex
 }
 
 // Get returns a data or nil.
@@ -145,4 +146,14 @@ func (c *FileCache) Set(key string, src []byte) error {
 	}
 
 	return nil
+}
+
+// NewFileCache is ...
+func NewFileCache(key string) (*FileCache, error) {
+	path, err := ioutil.TempDir("", key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &FileCache{path: path}, nil
 }

--- a/cache.go
+++ b/cache.go
@@ -132,8 +132,8 @@ func (c *FileCache) Set(key string, src []byte) error {
 }
 
 // NewFileCache is ...
-func NewFileCache(key string) (*FileCache, error) {
-	path, err := ioutil.TempDir("", key)
+func NewFileCache(prefix string) (*FileCache, error) {
+	path, err := ioutil.TempDir("", prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/cache.go
+++ b/cache.go
@@ -125,7 +125,8 @@ func (c *FileCache) Set(key string, src []byte) error {
 	return nil
 }
 
-// NewFileCache is ...
+// NewFileCache returns FileCache pointer.
+// If there is no temp directory named prefix, create temp directory for storing cache.
 func NewFileCache(prefix string) (*FileCache, error) {
 	path, err := ioutil.TempDir("", prefix)
 	if err != nil {

--- a/cache_test.go
+++ b/cache_test.go
@@ -105,7 +105,8 @@ func TestFileCache_Set(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			fc := &FileCache{}
+			fc, _ := NewFileCache("testPrefix")
+			defer os.RemoveAll(fc.path)
 			err := fc.Set(testKey, tt.arg)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("failed to set cache. err is %v but wantErr is %v", err, tt.wantErr)
@@ -129,7 +130,8 @@ func TestFileCache_Get(t *testing.T) {
 		{name: "failed to get cache for invalid key", key: "hoge", want: nil},
 	}
 
-	fc := &FileCache{}
+	fc, _ := NewFileCache("testPrefix")
+	defer os.RemoveAll(fc.path)
 	if err := fc.Set(testKey, []byte("hoge")); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -108,6 +108,7 @@ func TestFileCache_Set(t *testing.T) {
 			fc, _ := NewFileCache("testPrefix")
 			defer os.RemoveAll(fc.path)
 			err := fc.Set(testKey, tt.arg)
+
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("failed to set cache. err is %v but wantErr is %v", err, tt.wantErr)
 			}
@@ -127,11 +128,12 @@ func TestFileCache_Get(t *testing.T) {
 		want []byte
 	}{
 		{name: "success to get cache", key: testKey, want: []byte("hoge")},
-		{name: "failed to get cache for invalid key", key: "hoge", want: nil},
+		{name: "failed to get cache for key missing", key: "hoge", want: nil},
 	}
 
 	fc, _ := NewFileCache("testPrefix")
 	defer os.RemoveAll(fc.path)
+
 	if err := fc.Set(testKey, []byte("hoge")); err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/cache_test.go
+++ b/cache_test.go
@@ -9,18 +9,7 @@ import (
 var testKey = "testKey"
 
 func TestMain(m *testing.M) {
-	if _, err := os.Stat(fileCacheDir); os.IsNotExist(err) {
-		if err := os.Mkdir(fileCacheDir, os.ModePerm); err != nil {
-			panic(err)
-		}
-	}
-
 	ret := m.Run()
-
-	if err := os.RemoveAll(fileCacheDir); err != nil {
-		panic(err)
-	}
-
 	os.Exit(ret)
 }
 


### PR DESCRIPTION
## これは何か？

https://github.com/emahiro/glc/issues/9 に記載している内容を実装します。

### 追加

FileCache を New するときに、New した FileCache オブジェクトが Temp ファイル配下のどのディレクトリに保存するのか？という情報を持つ用意して、既存実装 において FileCache の key 名が同じときに意図しない cache の上書きを行ってしまう、という挙動を修正しました。

FileCache を New するときに `ioutil.TempDir` を使っているのは temp ディレクトリを作成するときに、自動的に指定した prefix  + {{ ランダムな数値 }} で temp 配下にディレクトリを掘ってくれるためです。

詳しくは https://godoc.org/io/ioutil#TempDir の Example を参照。