### PR TITLE
Fix/godoc 20191019

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ if err := mc.Set("cacheKey", []byte('hoge')); err != nil {
 }
 
 // Get
+
 data := mc.Get("cacheKey")
 ```
 
 ### file cache
 
 Usage is similar to in memory cache.  
-Go Local Cache creates `tmp` directory for file cache, when you provide UseFileCache true.
-If you use file cache without setting UseFileCache true, handle error due to missing `tmp` directory.
+Go Local Cache creates `tmp` directory for file cache.
 
 ## LICENSE
 

--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,6 @@
 /*
-Package cache is provides the local cache which is stored in memoroy or file.
-This package creates `tmp` directory for file cache, when you provide UseFileCache true.
+Package glc is provides the local cache which is stored in memoroy or file.
+This package creates `tmp` directory in case of using file cache.
 
 Example:
 	mc := glc.NewMemoryCache(glc.DefaultMemoryCacheExpires)

--- a/cache.go
+++ b/cache.go
@@ -44,7 +44,7 @@ type Item struct {
 }
 
 // Get returns a item or nil.
-// If cache in local is nil or expiration date of the cache you want to retrive is earlier, you can't retrive cache.
+// If cache in local is nil or expiration date of the cache is earlier, this returns nil.
 func (c *MemoryCache) Get(key string) []byte {
 	c.m.RLock()
 	defer c.m.RUnlock()
@@ -92,7 +92,7 @@ type FileCache struct {
 }
 
 // Get returns a data or nil.
-// If cache in local file is nil or you set key that does not hit the cache, you can not retrive cache.
+// If cache in local file is nil or is not setted key, this returns nil.
 func (c *FileCache) Get(key string) []byte {
 	c.m.RLock()
 	defer c.m.RUnlock()
@@ -107,8 +107,8 @@ func (c *FileCache) Get(key string) []byte {
 }
 
 // Set create a new file which is witten data as []byte.
-// When you set a new cache data, create a `{{ $key }}.cache` file,
-// and if cache file is exist, overwrite it.
+// When it sets a new cache data, create a `{{ $key }}.cache` file,
+// and overwrite it if cache file is exist.
 func (c *FileCache) Set(key string, src []byte) error {
 	if len(src) == 0 {
 		return fmt.Errorf("error: set no data")


### PR DESCRIPTION
## これは何か？
#25 に伴い、godoc、package doc、README.md を更新します。

主な変更点は以下です。

- fix package doc
  - package 名を変更したのに package doc の方を修正していなかった。
- fix godc
  - `you` というシステムのドキュメントにはおかしな言い回しを多用していたので修正
- update README
  - useFileCache フラグを #25 にて削除したので、そお記述を削除する