### PR TITLE
Update Go version to 1.24 and GitHub Actions dependencies

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -5,18 +5,18 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.20.x, 1.21.x]
+        go-version: [1.23.x, 1.24.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Test
         run: go test -v -cover .


### PR DESCRIPTION
This commit updates the Go versions used in the CI to 1.23.x and 1.24.x. It also updates the following GitHub Actions to their latest versions:
- actions/setup-go to v5
- actions/checkout to v4.2.2