### PR TITLE
Revert actions version pinning to major versions

### DIFF
--- a/.github/workflows/gotest.yml
+++ b/.github/workflows/gotest.yml
@@ -16,7 +16,7 @@ jobs:
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4
 
       - name: Test
         run: go test -v -cover .


### PR DESCRIPTION
This commit changes the GitHub Actions workflow file `.github/workflows/gotest.yml` to use major versions for Actions libraries instead of specific patch versions.

Specifically, `actions/checkout@v4.2.2` has been changed to `actions/checkout@v4`. This allows for automatic patch updates while maintaining compatibility with version 4.